### PR TITLE
Build script enhance

### DIFF
--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -1,20 +1,108 @@
 #!/bin/bash
 
-if [ ! -d build ]; then
-    mkdir build
-    (cd build && cmake ..)
-fi
+# variables
+canonical_file_name=`readlink -f ${0}`
+project_dir=`dirname ${canonical_file_name}`
+build_dir="${project_dir}/build"
+release_dir="${project_dir}/Build_Release"
+assets_dir="${release_dir}/ASSETS"
 
-echo "Build binary ..."
-cd build
-make -j$(nproc)
+assets_zip_filename="ASSETS.ZIP"
+assets_zip_file="${release_dir}/${assets_zip_filename}"
+openclaw_binary_file="${release_dir}/openclaw"
+compatible_binary_file="${release_dir}/OpenClaw"
 
-cd ../Build_Release
+# functions
 
-echo "Recreate ASSETS.ZIP ..."
-rm -f ASSETS.ZIP
-(cd ASSETS && zip -r ../ASSETS.ZIP .)
+##
+# Prepares the building process by creating a directory for cmake native build process. 
+# return: the result of [mkdir], [0] for success and [1] for failure.
+##
+function prepare() {
+    echo "Preparing the build directory ..."
+    if [ ! -d $build_dir ]; then
+        mkdir $build_dir
+    fi
+    return $?
+}
 
-echo "Run ..."
-cp openclaw OpenClaw
-./OpenClaw
+##
+# Generates the native build system for the project.
+# return: the result of [cmake] command.
+##
+function generateNativeBuildSystem() {
+    if [ ! -d $build_dir ]; then
+        return prepare
+    fi
+    echo "Generating the OpenClaw native build system ..."
+    cmake -S $project_dir -B $build_dir
+    return $?
+}
+
+##
+# Builds the openclaw engine and binaries into object files.
+# return: the result of [make] command.
+##
+function build() {
+    if [ ! -d $build_dir ]; then
+        return compile
+    fi
+    echo "Building the binary ..."
+    make -j$(nproc) -C "${build_dir}" 
+    return $?
+}   
+
+##
+# Zips the assets folder for the engine.
+# return: the result of [zip] command.
+## 
+function releaseAssets() {
+    if [ ! -d $release_dir ]; then
+        return compile
+    fi
+    echo "Recreating ASSETS.ZIP ..."
+    rm -f $assets_zip_file
+    cd ${assets_dir}
+    zip -r $assets_zip_filename .
+    cp $assets_zip_filename ..
+    rm $assets_zip_filename
+    return $?
+}
+
+##
+# Creates a claw binary to be compatible with the ClawLauncher.
+# return: the result of [cp] command, [0] for success and [1] for failure.
+##
+function createLauncherBinary() {
+    if [ ! -f $openclaw_binary_file ]; then
+        return build
+    fi
+    echo "Creating a compatible binary ..."
+    cp $openclaw_binary_file $compatible_binary_file
+    rm $openclaw_binary_file
+}
+
+##
+# Runs the openclaw binary.
+##
+function runOpenClaw() {
+    if [ ! -d $release_dir ]; then
+        return createLauncherBinary
+    fi
+    echo "Runing OpenClaw ..."
+    $compatible_binary_file
+}
+
+# command and execute
+
+prepare
+
+generateNativeBuildSystem
+
+build
+
+releaseAssets
+
+createLauncherBinary
+
+runOpenClaw

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -42,6 +42,7 @@ function prepare() {
     if [ -d $build_dir ]; then
         return 0
     fi
+
     mkdir $build_dir
 
     return $?
@@ -55,6 +56,7 @@ function generateNativeBuildSystem() {
     if [ ! -d $build_dir ]; then
         prepare
     fi
+
     print ${WHITE_C} "Generating the OpenClaw native build system ..."
     cmake -S $project_dir -B $build_dir
 
@@ -69,6 +71,7 @@ function build() {
     if [ ! -d $build_dir ]; then
         generateNativeBuildSystem
     fi
+
     print ${WHITE_C} "Building the binary ..."
     make -j$(nproc) -C "${build_dir}" 
 
@@ -83,12 +86,15 @@ function releaseAssets() {
     if [ ! -d $release_dir ]; then
         build
     fi
+
     print ${WHITE_C} "Recreating ASSETS.ZIP ..."
     rm -v $assets_zip_file
+
     cd ${assets_dir}
-    zip -r $assets_zip_filename .
-    cp $assets_zip_filename ..
-    rm $assets_zip_filename
+    zip -v -r $assets_zip_filename .
+
+    cp -v $assets_zip_filename ..
+    rm -v $assets_zip_filename
 
     return $?
 }
@@ -101,9 +107,11 @@ function createLauncherBinary() {
     if [ ! -f "${release_dir}/${openclaw_binary_file}" ]; then
         build
     fi
+
     print ${WHITE_C} "Creating a compatible binary ..."
-    cp "${release_dir}/${openclaw_binary_file}" "${release_dir}/${compatible_binary_file}"
-    rm "${release_dir}/${openclaw_binary_file}"
+
+    cp -v "${release_dir}/${openclaw_binary_file}" "${release_dir}/${compatible_binary_file}"
+    rm -v "${release_dir}/${openclaw_binary_file}"
 
     return $?
 }
@@ -115,7 +123,9 @@ function runOpenClaw() {
     if [ ! -f "${release_dir}/${compatible_binary_file}" ]; then
         createLauncherBinary
     fi
+
     print ${WHITE_C} "Runing OpenClaw ..."
+    
     # change directory for the engine to load actor prototypes !
     cd $release_dir
     "./${compatible_binary_file}"

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -33,10 +33,22 @@ function print() {
 }
 
 ##
+# Prepares the SDL-2-dev binaries to enable development of OpenClaw. 
+# return: the result of the apt package manager, [0] for success and [1] for failure.
+##
+function prepareSDL2() {
+    print ${WHITE_C} "Preparing SDL-2-dev dependencies ..."
+    
+    sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libsdl2-gfx-dev 
+
+    return $?
+}
+
+##
 # Prepares the building process by creating a directory for cmake native build process. 
 # return: the result of [mkdir], [0] for success and [1] for failure.
 ##
-function prepare() {
+function prepareBuildDirectory() {
     print ${WHITE_C} "Preparing the build directory ..."
     
     if [ -d $build_dir ]; then
@@ -125,14 +137,23 @@ function runOpenClaw() {
     fi
 
     print ${WHITE_C} "Runing OpenClaw ..."
-    
+
     # change directory for the engine to load actor prototypes !
     cd $release_dir
     "./${compatible_binary_file}"
 }
 
 # command and execute
-prepare
+prepareSDL2
+
+if [[ $? -ge 1 ]]; then 
+    print ${RED_C} "Preparing SDL-2-dev failed ..."
+    exit $?
+else
+    print ${GREEN_C} "Preparing SDL-2-dev succeeded ..."
+fi
+
+prepareBuildDirectory
 
 if [[ $? -ge 1 ]]; then 
     print ${RED_C} "Preparing build directory failed ..."


### PR DESCRIPTION
This PR has the follows: 
- [x] Use the canonical directory name as a `project_dir` variable for the build script (now you can run the script from anywhere !).
- [x]  Separated build script commands into functions indicating the build process.
- [x]  Added terminal colors indicating the current process status [Success/Failure]. 
- [x]  Added SDL-2-dev dependencies prepare function.
- [ ]  Added a `Claw.REZ` download function using `curl`.